### PR TITLE
Retirando código desnecessário

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,6 @@
     <!-- Custom styles for this template -->
     <link href="http://getbootstrap.com/examples/jumbotron-narrow/jumbotron-narrow.css" rel="stylesheet">
 
-    <!-- Just for debugging purposes. Don't actually copy these 2 lines! -->
-    <!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
-    <script src="http://getbootstrap.com/assets/js/ie-emulation-modes-warning.js"></script>
-
     <link href="img/favicon.ico" rel="Shortcut Icon">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
@@ -65,9 +61,6 @@
 
     </div> <!-- /container -->
 
-
-    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
   </body>
 
 <script>


### PR DESCRIPTION
O ie-emulation-modes-warning.js não deve ser incluído na página (o próprio código dele fala não deve ser usado em produção). Já o ie10-viewport-bug-workaround.js não existe no servidor (404).
