### PR TITLE
Renomeando AngularJS para Angular na página inicial

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8">
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="keywords" content="JAVA,JEE7,HTML5,CSS,XML,JavaScript,AngularJS,SERPRO">
+    <meta name="keywords" content="JAVA,JEE7,HTML5,CSS,XML,JavaScript,Angular,SERPRO">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
-    <meta name="description" content="O Demoiselle Framework implementa o conceito de framework integrador JEE7 com AngularJS">
+    <meta name="description" content="O Demoiselle Framework implementa o conceito de framework integrador JEE7 com Angular">
     <meta name="author" content="Demoiselle">
     <meta name="google-site-verification" content="mNHCer1uy6QCsKv_7CMOnET5jG4SHWJ3Q_P3TzuK5Ug" />
 
@@ -228,7 +228,7 @@
                         <img itemprop="image" src="img/portfolio/logo-demoiselle-products.png" class="img-responsive" alt="">
                     </a>
                     <div class="portfolio-caption">
-                        <h4 itemprop="name">JEE7 e AngularJS</h4>
+                        <h4 itemprop="name">JEE7 e Angular</h4>
                         <p itemprop="brand" class="text-muted">Software</p>
                     </div>
                 </div>


### PR DESCRIPTION
Dado que o Demoiselle já usa as versões Angular 2+, para evitar confusão com a versão antiga do angular (1.0), aka AngularJS/Angular.js , achei interessante renomear o painel da página principal para apenas "Angular".

O que acham? Esqueci de alterar em mais cantos do projeto, ou apenas o index.html basta?

Valeu.